### PR TITLE
Bound C string terminator search

### DIFF
--- a/protocol/shared.ml
+++ b/protocol/shared.ml
@@ -140,14 +140,15 @@ let[@inline always] fill_int32_be iobuf value =
 ;;
 
 let find_null_exn iobuf =
-  let rec loop ~iobuf ~length ~pos =
-    if Char.( = ) (Iobuf.Peek.char iobuf ~pos) '\x00'
-    then pos
-    else if pos > length - 1
-    then failwith "find_null_exn could not find \\x00"
-    else loop ~iobuf ~length ~pos:(pos + 1)
-  in
-  loop ~iobuf ~length:(Iobuf.length iobuf) ~pos:0
+  match Iobuf.Peek.index iobuf '\x00' with
+  | Some pos -> pos
+  | None -> failwith "find_null_exn could not find \\x00"
+;;
+
+let%test_unit "find_null_exn handles a missing terminator" =
+  match find_null_exn (Iobuf.of_string "not terminated") with
+  | exception Failure "find_null_exn could not find \\x00" -> ()
+  | _ -> failwith "find_null_exn should reject a missing terminator"
 ;;
 
 let consume_cstring_exn iobuf =


### PR DESCRIPTION
Fixes #4.

`find_null_exn` peeked at each byte before verifying that the offset was still inside the iobuf. A malformed backend message without a null terminator therefore raised an accidental bounds exception before reaching the intended missing-terminator error.

Use `Iobuf.Peek.index` for the bounded search and add an inline regression for an unterminated string. The normal terminated path is unchanged; the malformed path now fails deliberately with the existing missing-terminator error. `Null_terminated_string.consume_exn` in the same module already uses `Iobuf.Peek.index` for the equivalent bounded scan, so this aligns the second parser path with the existing implementation.

Validation:
- `git diff --check`
- added inline malformed-input regression for a missing null terminator
- private Linux runner: `opam install . --deps-only --with-test -y` completed and `dune build @all -j2` reached source compilation; the current repository baseline then stopped in unchanged `protocol/shared.mli` because it expects the internal four-parameter `Iobuf.Fill.t` API while the released public `core_kernel` exposes three parameters, so `dune runtest` is not reachable with the public package set
- `dune build @fmt` is also blocked by repository-baseline Dune formatting drift and a missing public `ocamlformat` binary